### PR TITLE
fix: Update descriptions and button order

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,8 +9,8 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
-  title: "Jason Schramm's Portfolio",
-  description: "Portfolio of Jason Schramm",
+  title: "Connect with Jason",
+  description: "Connect with a Senior Full Stack Web Developer interested in working with organizations making a positive social or environmental impact.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,9 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 
 const externalLinks = [
+	{ href: 'https://www.linkedin.com/in/j-schramm/', label: 'LinkedIn' },
 	{ href: '/assets/JasonSchramm_Resume.pdf', label: 'Resume' },
 	{ href: 'https://github.com/jruns', label: 'GitHub' },
-	{ href: 'https://www.linkedin.com/in/j-schramm/', label: 'LinkedIn' },
 	{ href: 'mailto:jason.schramm@gmail.com', label: 'Email Me' }
 ];
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
         <Header />
         <div className="flex flex-col">
             <div className="mt-4">
-              <p className="font-montserrat text-base tracking-wide">I am a <span className="highlights">Senior Full Stack Web Developer</span> looking for opportunities in the <span className="highlights">social or environmental impact</span> space at an organization <span className="highlights">making positive changes</span> in the world.</p>
+              <p className="font-montserrat text-base tracking-wide">I am a <span className="highlights">Senior Full Stack Web Developer</span> interested in <span className="highlights">working with organizations</span> making a positive <span className="highlights">social or environmental impact</span>.</p>
             </div>
             <div className="flex flex-row flex-wrap gap-x-4 gap-y-5 mt-8 mb-9">
               { externalLinks.map( (link, i) => (


### PR DESCRIPTION
- Update page title
- Update homepage description and meta description
- Move LinkedIn button to the beginning of connection links